### PR TITLE
[PLATFORM-5412] Update version to prevent matching latest official release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mock-firestore",
-    version="0.11.0",
+    version="0.11.1",
     author="Matt Dowds",
     description="In-memory implementation of Google Cloud Firestore for use in tests",
     long_description=long_description,
@@ -19,6 +19,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.12',
         "License :: OSI Approved :: MIT License",
     ],
 )


### PR DESCRIPTION
We are replacing build from source by a wheel. Bumping version to avoid matching the official version in pypi